### PR TITLE
Add token authentication support for the google home api

### DIFF
--- a/googledevices/api/cast/assistant.py
+++ b/googledevices/api/cast/assistant.py
@@ -1,5 +1,5 @@
 """Controll Assistant settings on the unit."""
-from googledevices.utils.const import CASTPORT, HEADERS
+from googledevices.utils.const import CASTSECPORT, HEADERS
 from googledevices.helpers import gdh_request
 import googledevices.utils.log as log
 
@@ -15,12 +15,14 @@ class Assistant(object):
         self._alarms = []
         self._alarmvolume = None
 
-    async def set_night_mode_params(self, data):
+    async def set_night_mode_params(self, token, data):
         """Set night mode options."""
         endpoint = "setup/assistant/set_night_mode_params"
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -30,13 +32,15 @@ class Assistant(object):
         )
         return result
 
-    async def notifications_enabled(self, mode=True):
+    async def notifications_enabled(self, token, mode=True):
         """Set notifications_enabled True/False."""
         endpoint = "setup/assistant/notifications"
         data = {"notifications_enabled": mode}
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -46,13 +50,15 @@ class Assistant(object):
         )
         return result
 
-    async def set_accessibility(self, start=True, end=False):
+    async def set_accessibility(self, token, start=True, end=False):
         """Set accessibility True/False."""
         endpoint = "setup/assistant/a11y_mode"
         data = {"endpoint_enabled": end, "hotword_enabled": start}
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -62,12 +68,14 @@ class Assistant(object):
         )
         return result
 
-    async def delete_alarms(self, data):
+    async def delete_alarms(self, token, data):
         """Delete active alarms and timers."""
         endpoint = "setup/assistant/alarms/delete"
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -77,7 +85,7 @@ class Assistant(object):
         )
         return result
 
-    async def set_equalizer(self, low_gain=0, high_gain=0):
+    async def set_equalizer(self, token, low_gain=0, high_gain=0):
         """Set equalizer db gain."""
         endpoint = "setup/user_eq/set_equalizer"
         returnvalue = False
@@ -86,8 +94,10 @@ class Assistant(object):
             "high_shelf": {"gain_db": high_gain},
         }
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -104,12 +114,14 @@ class Assistant(object):
             log.error(msg)
         return returnvalue
 
-    async def get_alarms(self):
+    async def get_alarms(self, token):
         """Get the alarms from the device."""
         endpoint = "setup/assistant/alarms"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -119,12 +131,14 @@ class Assistant(object):
         log.debug(self._alarms)
         return self._alarms
 
-    async def get_alarm_volume(self):
+    async def get_alarm_volume(self, token):
         """Get the alarm volume for the device."""
         endpoint = "setup/assistant/alarms/volume"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -135,14 +149,16 @@ class Assistant(object):
         log.debug(self._alarmvolume)
         return self._alarmvolume
 
-    async def set_alarm_volume(self, volume):
+    async def set_alarm_volume(self, token, volume):
         """Set the alarm volume for the device."""
         data = {"volume": volume}
         endpoint = "setup/assistant/alarms/volume"
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,

--- a/googledevices/api/cast/bluetooth.py
+++ b/googledevices/api/cast/bluetooth.py
@@ -1,6 +1,6 @@
 """Bluetooth handling on Google Home units."""
 from googledevices.helpers import gdh_request
-from googledevices.utils.const import HEADERS, CASTPORT
+from googledevices.utils.const import HEADERS, CASTSECPORT
 import googledevices.utils.log as log
 
 
@@ -16,12 +16,14 @@ class Bluetooth(object):
         self._paired_devices = []
         self._status = {}
 
-    async def get_bluetooth_status(self):
+    async def get_bluetooth_status(self, token):
         """Get the bluetooth status of the device."""
         endpoint = "setup/bluetooth/status"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -31,12 +33,14 @@ class Bluetooth(object):
         log.debug(self._status)
         return self._status
 
-    async def get_paired_devices(self):
+    async def get_paired_devices(self, token):
         """Get paired devices."""
         endpoint = "setup/bluetooth/get_bonded"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -46,14 +50,16 @@ class Bluetooth(object):
         log.debug(self._status)
         return self._status
 
-    async def forget_paired_device(self, mac_address):
+    async def forget_paired_device(self, token, mac_address):
         """Forget a paired device."""
         endpoint = "setup/bluetooth/bond"
         data = {"bond": False, "mac_address": mac_address}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -70,14 +76,16 @@ class Bluetooth(object):
             log.error(msg)
         return returnvalue
 
-    async def set_discovery_enabled(self):
+    async def set_discovery_enabled(self, token):
         """Enable bluetooth discoverablility."""
         endpoint = "setup/bluetooth/discovery"
         data = {"enable_discovery": True}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -94,14 +102,16 @@ class Bluetooth(object):
             log.error(msg)
         return returnvalue
 
-    async def pair_with_mac(self, mac_address):
+    async def pair_with_mac(self, token, mac_address):
         """Pair with bluetooth device."""
         endpoint = "setup/bluetooth/scan"
         data = {"connect": True, "mac_address": mac_address, "profile": 2}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -118,14 +128,16 @@ class Bluetooth(object):
             log.error(msg)
         return returnvalue
 
-    async def scan_for_devices(self):
+    async def scan_for_devices(self, token):
         """Scan for bluetooth devices."""
         endpoint = "setup/bluetooth/scan"
         data = {"enable": True, "clear_results": True, "timeout": 5}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -142,12 +154,14 @@ class Bluetooth(object):
             log.error(msg)
         return returnvalue
 
-    async def get_scan_result(self):
+    async def get_scan_result(self, token):
         """Scan for bluetooth devices."""
         endpoint = "setup/bluetooth/scan_results"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,

--- a/googledevices/api/cast/info.py
+++ b/googledevices/api/cast/info.py
@@ -1,5 +1,5 @@
 """Get device information for the unit."""
-from googledevices.utils.const import DEFAULT_DEVICE_NAME, CASTPORT, HEADERS
+from googledevices.utils.const import DEFAULT_DEVICE_NAME, CASTPORT, CASTSECPORT, HEADERS
 import googledevices.utils.log as log
 from googledevices.helpers import gdh_request
 
@@ -19,7 +19,7 @@ class Info(object):  # pylint: disable=R0902
         self._locales = []
         self._app_device_id = {}
 
-    async def get_device_info(self):
+    async def get_device_info(self, token = None):
         """Get device information for the unit."""
         endpoint = "setup/eureka_info"
         params = (
@@ -28,11 +28,13 @@ class Info(object):  # pylint: disable=R0902
             "night_mode_params,user_eq,room_equalizer&options=detail"
         )
         response = await gdh_request(
+            schema="https" if token is not None else "http",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT if token is not None else CASTPORT,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
+            token=token,
             params=params,
             headers=HEADERS,
         )
@@ -40,12 +42,14 @@ class Info(object):  # pylint: disable=R0902
         log.debug(self._device_info)
         return self._device_info
 
-    async def get_offer(self):
+    async def get_offer(self, token):
         """Get offer token."""
         endpoint = "setup/offer"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -55,12 +59,14 @@ class Info(object):  # pylint: disable=R0902
         log.debug(self._offer)
         return self._offer
 
-    async def get_timezones(self):
+    async def get_timezones(self, token):
         """Get supported timezones."""
         endpoint = "setup/supported_timezones"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -70,12 +76,14 @@ class Info(object):  # pylint: disable=R0902
         log.debug(self._timezones)
         return self._timezones
 
-    async def get_locales(self):
+    async def get_locales(self, token):
         """Get supported locales."""
         endpoint = "setup/supported_locales"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -85,14 +93,16 @@ class Info(object):  # pylint: disable=R0902
         log.debug(self._locales)
         return self._locales
 
-    async def speedtest(self):
+    async def speedtest(self, token):
         """Run speedtest."""
         endpoint = "setup/test_internet_download_speed"
         url = "https://storage.googleapis.com/reliability-speedtest/random.txt"
         data = {"url": url}
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -102,13 +112,15 @@ class Info(object):  # pylint: disable=R0902
         )
         return result
 
-    async def get_app_device_id(self):
+    async def get_app_device_id(self, token):
         """Run speedtest."""
         endpoint = "setup/get_app_device_id"
         data = {"app_id": "E8C28D3C"}
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,

--- a/googledevices/api/cast/settings.py
+++ b/googledevices/api/cast/settings.py
@@ -1,5 +1,5 @@
 """Controll device settings on the unit."""
-from googledevices.utils.const import CASTPORT, HEADERS
+from googledevices.utils.const import CASTSECPORT, HEADERS
 from googledevices.helpers import gdh_request
 import googledevices.utils.log as log
 
@@ -13,7 +13,7 @@ class Settings(object):
         self.loop = loop
         self.session = session
 
-    async def reboot(self, mode="now"):
+    async def reboot(self, token, mode="now"):
         """Reboot the device."""
         endpoint = "setup/reboot"
         supported_modes = ["now", "fdr"]
@@ -24,8 +24,10 @@ class Settings(object):
             return returnvalue
         data = {"params": mode}
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -42,13 +44,15 @@ class Settings(object):
             log.error(msg)
         return returnvalue
 
-    async def set_eureka_info(self, data):
+    async def set_eureka_info(self, token, data):
         """Set eureka info."""
         endpoint = "setup/set_eureka_info"
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -65,15 +69,17 @@ class Settings(object):
             log.error(msg)
         return returnvalue
 
-    async def control_notifications(self, active):
+    async def control_notifications(self, token, active):
         """Set control_notifications option."""
         endpoint = "setup/set_eureka_info"
         value = 1 if active else 2
         data = {"settings": {"control_notifications": value}}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,

--- a/googledevices/api/cast/wifi.py
+++ b/googledevices/api/cast/wifi.py
@@ -1,6 +1,6 @@
 """Wifi handling on Google Home units."""
 from googledevices.helpers import gdh_request
-from googledevices.utils.const import HEADERS, CASTPORT
+from googledevices.utils.const import HEADERS, CASTSECPORT
 import googledevices.utils.log as log
 
 
@@ -15,12 +15,14 @@ class Wifi(object):
         self._configured_networks = None
         self._nearby_networks = None
 
-    async def get_configured_networks(self):
+    async def get_configured_networks(self, token):
         """Get the configured networks of the device."""
         endpoint = "setup/configured_networks"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -30,12 +32,14 @@ class Wifi(object):
         log.debug(self._configured_networks)
         return self._configured_networks
 
-    async def get_wifi_scan_result(self):
+    async def get_wifi_scan_result(self, token):
         """Get the result of a wifi scan."""
         endpoint = "setup/configured_networks"
         response = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             loop=self.loop,
             session=self.session,
             endpoint=endpoint,
@@ -45,13 +49,15 @@ class Wifi(object):
         log.debug(self._configured_networks)
         return self._configured_networks
 
-    async def scan_for_wifi(self):
+    async def scan_for_wifi(self, token):
         """Scan for nearby wifi networks."""
         endpoint = "setup/scan_wifi"
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,
@@ -67,15 +73,17 @@ class Wifi(object):
             log.error(msg)
         return returnvalue
 
-    async def forget_network(self, wpa_id):
+    async def forget_network(self, token, wpa_id):
         """Forget a network."""
         endpoint = "setup/forget_wifi"
         returnvalue = False
         data = {"wpa_id": int(wpa_id)}
         returnvalue = False
         result = await gdh_request(
+            schema="https",
             host=self.host,
-            port=CASTPORT,
+            port=CASTSECPORT,
+            token=token,
             endpoint=endpoint,
             method="post",
             loop=self.loop,

--- a/googledevices/api/wifi/clients.py
+++ b/googledevices/api/wifi/clients.py
@@ -31,7 +31,7 @@ class Clients(object):
             await log.error("Host is 'None', host can not be 'None'")
             return self._clients
         endpoint = WIFIAPIPREFIX + "diagnostic-report"
-        url = API.format(host=self.info.wifi_host, port=":80", endpoint=endpoint)
+        url = API.format(schema="http", host=self.info.wifi_host, port=":80", endpoint=endpoint)
         try:
             response = requests.request("GET", url)
             all_clients = response.text

--- a/googledevices/api/wifi/info.py
+++ b/googledevices/api/wifi/info.py
@@ -30,7 +30,7 @@ class Info(object):
                         self.loop = gdh_loop()
                     if self.session is None:
                         self.session = gdh_session()
-                    url = API.format(host=host, port="", endpoint=self.endpoint)
+                    url = API.format(schema="http", host=host, port="", endpoint=self.endpoint)
                     async with async_timeout.timeout(5, loop=self.loop):
                         await self.session.get(url)
                         self._wifi_host = host

--- a/googledevices/helpers.py
+++ b/googledevices/helpers.py
@@ -27,7 +27,9 @@ async def gdh_sleep(seconds=5):
 
 async def gdh_request(
     host,
+    schema=None,
     port=None,
+    token=None,
     endpoint=None,
     json=True,
     session=None,
@@ -46,12 +48,18 @@ async def gdh_request(
     from googledevices.utils.const import API
     import googledevices.utils.log as log
 
+    if schema is None:
+        schema = "http"
     if port is not None:
         port = ":{port}".format(port=port)
     else:
         port = ""
-    url = API.format(host=host, port=port, endpoint=endpoint)
+    url = API.format(schema=schema, host=host, port=port, endpoint=endpoint)
     result = None
+    if token is not None:
+        if headers is None:
+            headers = {}
+        headers["cast-local-authorization-token"] = token
 
     if session is None:
         session = gdh_session()
@@ -61,11 +69,11 @@ async def gdh_request(
         async with async_timeout.timeout(8, loop=loop):
             if method == "post":
                 webrequest = await session.post(
-                    url, json=json_data, data=data, params=params, headers=headers
+                    url, json=json_data, data=data, params=params, headers=headers, ssl=False
                 )
             else:
                 webrequest = await session.get(
-                    url, json=json_data, data=data, params=params, headers=headers
+                    url, json=json_data, data=data, params=params, headers=headers, ssl=False
                 )
             if json:
                 result = await webrequest.json()

--- a/googledevices/utils/const.py
+++ b/googledevices/utils/const.py
@@ -2,7 +2,7 @@
 ###############################################################################
 # General
 ###############################################################################
-API = "http://{host}{port}/{endpoint}"
+API = "{schema}://{host}{port}/{endpoint}"
 DEFAULT_DEVICE_NAME = "GoogleDevice"
 HEADERS = {"Content-Type": "application/json", "Host": "localhost"}
 PLATFORMS = ["cast", "wifi"]
@@ -11,6 +11,7 @@ PLATFORMS = ["cast", "wifi"]
 # Cast API
 ###############################################################################
 CASTPORT = 8008
+CASTSECPORT = 8443
 
 ###############################################################################
 # WiFI API


### PR DESCRIPTION
Since June 2019 the Google Home Local API requires authentication using a "local authorization token" for most requests. This PR changes the affected api requests to send a user-provided authentication token and switch to the now used port 8443 for the api.

A special case is the eureka_info endpoint, that can still be accessed over the old port without authentication, but provides more information, when accessed over an encrypted and authorized connection. The method thus supports calling with AND without a token.

All endpoints still work the same otherwise. There are no means added to get such a token. This remains up the library user.
However there exist [multiple options](https://rithvikvibhu.github.io/GHLocalApi/#section/Google-Home-Local-API/Authentication) since quite some time to get such token.

Recently a new [method was discovered](https://gist.github.com/rithvikvibhu/952f83ea656c6782fbd0f1645059055d), that can be setup without frequent access to an rooted android device. As a result I was able to [revive the old googlehome home-assistant integration as a custom component](https://github.com/Drakulix/googlehome).

I would like to upstream this component eventually and therefor need to upstream my patches to this library at first.
Please tell me, if this approach is fine to you or if you would like to see any changes to this PR.
If merged this would probably fix(?) #44 .